### PR TITLE
feat/seperate-article-and-content : article과 content 분리하기

### DIFF
--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -4,7 +4,7 @@ const API_ARTICLE_URL_FOR_SSR = `${API_URL_FOR_SSR}/api/articles`
 const API_ARTICLE_URL_FOR_CSR = `${API_URL_FOR_CSR}/api/articles`
 
 export interface ArticleContentInterface {
-  _id: string
+  _id?: string
   text: string
   html: string
 }

--- a/src/apis/articles.ts
+++ b/src/apis/articles.ts
@@ -4,6 +4,7 @@ const API_ARTICLE_URL_FOR_SSR = `${API_URL_FOR_SSR}/api/articles`
 const API_ARTICLE_URL_FOR_CSR = `${API_URL_FOR_CSR}/api/articles`
 
 export interface ArticleContentInterface {
+  _id: string
   text: string
   html: string
 }

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { connectMongoDB } from '@/libs/mongodb'
-import { Article } from '@/models/article'
+import { Article, ArticleContent } from '@/models/article'
 
 export const PUT = async (
   request: NextRequest,
@@ -11,9 +11,20 @@ export const PUT = async (
     params: { id: string }
   },
 ) => {
-  const { newTitle: title, newContent: content } = await request.json()
+  const {
+    newTitle: title,
+    newContent: { text, html },
+  } = await request.json()
+
   await connectMongoDB()
-  await Article.findByIdAndUpdate(id, { title, content })
+
+  const { content: contentId } = await Article.findByIdAndUpdate(id, { title })
+
+  await ArticleContent.findByIdAndUpdate(contentId, {
+    text,
+    html,
+  })
+
   return NextResponse.json({ message: 'Article updated' }, { status: 200 })
 }
 

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { connectMongoDB } from '@/libs/mongodb'
-import Article from '@/models/article'
+import { Article } from '@/models/article'
 
 export const PUT = async (
   request: NextRequest,
@@ -26,6 +26,7 @@ export const GET = async (
   },
 ) => {
   await connectMongoDB()
-  const article = await Article.findOne({ _id: id })
+  const article = await Article.findOne({ _id: id }).populate('content')
+
   return NextResponse.json({ article }, { status: 200 })
 }

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -44,7 +44,11 @@ export const GET = async (request: NextRequest) => {
 
 export const DELETE = async (request: NextRequest) => {
   const id = request.nextUrl.searchParams.get('id')
+
   await connectMongoDB()
-  await Article.findByIdAndDelete(id)
+
+  const { content: contentId } = await Article.findByIdAndDelete(id)
+  await ArticleContent.findByIdAndDelete(contentId)
+
   return NextResponse.json({ message: 'Article deleted' }, { status: 200 })
 }

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -17,7 +17,7 @@ export const POST = async (request: NextRequest) => {
   })
   const { _id: articleId } = await Article.create({
     title,
-    articleContentId,
+    content: articleContentId,
   })
 
   return NextResponse.json({ message: articleId.toString() }, { status: 201 })
@@ -36,7 +36,7 @@ export const GET = async (request: NextRequest) => {
   }
 
   const articles = searchTerm
-    ? await Article.find(searchCondition)
+    ? await Article.find(searchCondition).populate('content')
     : await Article.find()
 
   return NextResponse.json({ articles })

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -1,16 +1,26 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { connectMongoDB } from '@/libs/mongodb'
-import Article from '@/models/article'
+import { Article, ArticleContent } from '@/models/article'
+import { ArticleInterface } from '@/apis/articles'
 
 export const POST = async (request: NextRequest) => {
-  const { title, content } = await request.json()
+  const {
+    title,
+    content: { text, html },
+  }: ArticleInterface = await request.json()
   await connectMongoDB()
 
-  const createdInfo = await Article.create({ title, content })
-  const { _id } = createdInfo
+  const { _id: articleContentId } = await ArticleContent.create({
+    text,
+    html,
+  })
+  const { _id: articleId } = await Article.create({
+    title,
+    articleContentId,
+  })
 
-  return NextResponse.json({ message: _id.toString() }, { status: 201 })
+  return NextResponse.json({ message: articleId.toString() }, { status: 201 })
 }
 
 export const GET = async (request: NextRequest) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ const HomePage = async ({
   const { q: searchTerm } = searchParams
 
   const loadedArticles = async (): Promise<
-    GetArticlesResponseInterface | undefined
+    GetArticlesResponseInterface['articles'] | undefined
   > => {
     try {
       const res = await getArticles(searchTerm)
@@ -18,14 +18,21 @@ const HomePage = async ({
         throw new Error('Failed to fetch articles')
       }
 
-      return res.json()
+      const { articles }: GetArticlesResponseInterface = await res.json()
+
+      if (!articles.length) return undefined
+
+      const latestSortedResult = articles.sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+      )
+
+      return latestSortedResult
     } catch (error) {
       console.log('Error loading articles:', error)
     }
   }
   const data = await loadedArticles()
-
-  if (!data) return
 
   return <Home data={data} />
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,9 +32,9 @@ const HomePage = async ({
       console.log('Error loading articles:', error)
     }
   }
-  const data = await loadedArticles()
+  const articles = await loadedArticles()
 
-  return <Home data={data} />
+  return <Home articles={articles} />
 }
 
 export default HomePage

--- a/src/components/ArticleForm/Editor/index.tsx
+++ b/src/components/ArticleForm/Editor/index.tsx
@@ -9,7 +9,7 @@ import { ArticleInterface } from '@/apis/articles'
 import { storage } from '@/Firebase'
 
 import { FORMATS, convertModules } from './_shared'
-import { HandleChangeNewContentType } from '..'
+import { HandleChangeNewContentType } from '../_shared'
 
 interface Props {
   contentHtml: ArticleInterface['content']['html']

--- a/src/components/ArticleForm/Editor/index.tsx
+++ b/src/components/ArticleForm/Editor/index.tsx
@@ -9,10 +9,11 @@ import { ArticleInterface } from '@/apis/articles'
 import { storage } from '@/Firebase'
 
 import { FORMATS, convertModules } from './_shared'
+import { HandleChangeNewContentType } from '..'
 
 interface Props {
   contentHtml: ArticleInterface['content']['html']
-  onChangeContent: (value: ArticleInterface['content']) => void
+  onChangeContent: (content: HandleChangeNewContentType) => void
 }
 
 const Editor = ({ contentHtml, onChangeContent }: Props) => {
@@ -66,7 +67,10 @@ const Editor = ({ contentHtml, onChangeContent }: Props) => {
       theme="snow"
       style={{ height: '600px' }}
       onChange={(value, delta, source, editor) =>
-        onChangeContent({ text: editor.getText(), html: editor.getHTML() })
+        onChangeContent({
+          text: editor.getText(),
+          html: editor.getHTML(),
+        })
       }
       modules={modules}
       formats={FORMATS}

--- a/src/components/ArticleForm/_shared/index.ts
+++ b/src/components/ArticleForm/_shared/index.ts
@@ -1,0 +1,6 @@
+export type {
+  ArticleFormProps,
+  NewTitleType,
+  NewContentType,
+  HandleChangeNewContentType,
+} from './types'

--- a/src/components/ArticleForm/_shared/types.ts
+++ b/src/components/ArticleForm/_shared/types.ts
@@ -1,0 +1,10 @@
+import { ArticleInterface } from '@/apis/articles'
+
+export interface ArticleFormProps extends ArticleInterface {
+  onSubmit: (article: ArticleInterface) => Promise<void>
+}
+
+export type NewTitleType = ArticleInterface['title']
+export type NewContentType = ArticleInterface['content']
+
+export type HandleChangeNewContentType = Pick<NewContentType, 'html' | 'text'>

--- a/src/components/ArticleForm/index.tsx
+++ b/src/components/ArticleForm/index.tsx
@@ -2,21 +2,11 @@
 
 import { ChangeEvent, FormEvent, useState } from 'react'
 
-import { ArticleInterface } from '@/apis/articles'
-
 import Editor from './Editor'
 import ArticleContent from '../ArticleContent'
+import { ArticleFormProps, NewContentType, NewTitleType } from './_shared'
 
-interface Props extends ArticleInterface {
-  onSubmit: (article: ArticleInterface) => Promise<void>
-}
-
-type NewTitleType = ArticleInterface['title']
-type NewContentType = ArticleInterface['content']
-
-export type HandleChangeNewContentType = Pick<NewContentType, 'html' | 'text'>
-
-const ArticleForm = ({ title, content, onSubmit }: Props) => {
+const ArticleForm = ({ title, content, onSubmit }: ArticleFormProps) => {
   const [newTitle, setNewTitle] = useState<NewTitleType>(title)
   const [newContent, setNewContent] = useState<NewContentType>(content)
 

--- a/src/components/ArticleForm/index.tsx
+++ b/src/components/ArticleForm/index.tsx
@@ -11,17 +11,23 @@ interface Props extends ArticleInterface {
   onSubmit: (article: ArticleInterface) => Promise<void>
 }
 
+type NewTitleType = ArticleInterface['title']
+type NewContentType = ArticleInterface['content']
+
+export type HandleChangeNewContentType = Pick<NewContentType, 'html' | 'text'>
+
 const ArticleForm = ({ title, content, onSubmit }: Props) => {
-  const [newTitle, setNewTitle] = useState<ArticleInterface['title']>(title)
-  const [newContent, setNewContent] =
-    useState<ArticleInterface['content']>(content)
+  const [newTitle, setNewTitle] = useState<NewTitleType>(title)
+  const [newContent, setNewContent] = useState<NewContentType>(content)
 
   const handleChangeNewTitle = ({
     target: { value },
   }: ChangeEvent<HTMLInputElement>) => setNewTitle(value)
 
-  const handleChangeNewContent = (value: ArticleInterface['content']) => {
-    setNewContent(value)
+  const handleChangeNewContent = (
+    content: Pick<NewContentType, 'html' | 'text'>,
+  ) => {
+    setNewContent((prev) => ({ ...prev, ...content }))
   }
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {

--- a/src/components/ArticleForm/index.tsx
+++ b/src/components/ArticleForm/index.tsx
@@ -11,13 +11,13 @@ const ArticleForm = ({ title, content, onSubmit }: ArticleFormProps) => {
   const [newContent, setNewContent] = useState<NewContentType>(content)
 
   const handleChangeNewTitle = ({
-    target: { value },
-  }: ChangeEvent<HTMLInputElement>) => setNewTitle(value)
+    target: { value: changedNewTitle },
+  }: ChangeEvent<HTMLInputElement>) => setNewTitle(changedNewTitle)
 
   const handleChangeNewContent = (
-    content: Pick<NewContentType, 'html' | 'text'>,
+    changedNewContent: Pick<NewContentType, 'html' | 'text'>,
   ) => {
-    setNewContent((prev) => ({ ...prev, ...content }))
+    setNewContent((prev) => ({ ...prev, ...changedNewContent }))
   }
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {

--- a/src/containers/Article/Read/DeleteButton/index.tsx
+++ b/src/containers/Article/Read/DeleteButton/index.tsx
@@ -16,6 +16,7 @@ const DeleteButton = ({ id }: { id: string }) => {
       const res = await deleteArticleById(id)
 
       if (!res.ok) {
+        router.push('/')
         throw new Error('Failed to delete an article.')
       }
 

--- a/src/containers/Home/index.tsx
+++ b/src/containers/Home/index.tsx
@@ -13,11 +13,10 @@ const Home = ({ articles }: Props) => {
     <main>
       <Search />
       {articles ? (
-        articles.map(({ title, content, _id }, idx) => (
-          <Link key={`${title}-${idx}`} href={`/article/${_id}`}>
+        articles.map(({ title, content: contentId, _id }) => (
+          <Link key={_id} href={`/article/${contentId}`}>
             <div style={{ border: '1px solid black' }}>
               <div>{title}</div>
-              <div>{content?.text}</div>
             </div>
           </Link>
         ))

--- a/src/containers/Home/index.tsx
+++ b/src/containers/Home/index.tsx
@@ -13,8 +13,8 @@ const Home = ({ articles }: Props) => {
     <main>
       <Search />
       {articles ? (
-        articles.map(({ title, content: contentId, _id }) => (
-          <Link key={_id} href={`/article/${contentId}`}>
+        articles.map(({ title, _id }) => (
+          <Link key={_id} href={`/article/${_id}`}>
             <div style={{ border: '1px solid black' }}>
               <div>{title}</div>
             </div>

--- a/src/containers/Home/index.tsx
+++ b/src/containers/Home/index.tsx
@@ -1,25 +1,29 @@
 import Link from 'next/link'
 
-import { GetArticlesResponseInterface } from '@/apis/articles'
+import { GetArticleInterface } from '@/apis/articles'
 
 import Search from './Search'
 
 interface Props {
-  data: GetArticlesResponseInterface
+  data: GetArticleInterface[] | undefined
 }
 
 const Home = ({ data }: Props) => {
   return (
     <main>
       <Search />
-      {data.articles?.map(({ title, content, _id }, idx) => (
-        <Link key={`${title}-${idx}`} href={`/article/${_id}`}>
-          <div style={{ border: '1px solid black' }}>
-            <div>{title}</div>
-            <div>{content?.text}</div>
-          </div>
-        </Link>
-      ))}
+      {data ? (
+        data.map(({ title, content, _id }, idx) => (
+          <Link key={`${title}-${idx}`} href={`/article/${_id}`}>
+            <div style={{ border: '1px solid black' }}>
+              <div>{title}</div>
+              <div>{content?.text}</div>
+            </div>
+          </Link>
+        ))
+      ) : (
+        <div>작성된 글이 없습니다.</div>
+      )}
     </main>
   )
 }

--- a/src/containers/Home/index.tsx
+++ b/src/containers/Home/index.tsx
@@ -5,15 +5,15 @@ import { GetArticleInterface } from '@/apis/articles'
 import Search from './Search'
 
 interface Props {
-  data: GetArticleInterface[] | undefined
+  articles: GetArticleInterface[] | undefined
 }
 
-const Home = ({ data }: Props) => {
+const Home = ({ articles }: Props) => {
   return (
     <main>
       <Search />
-      {data ? (
-        data.map(({ title, content, _id }, idx) => (
+      {articles ? (
+        articles.map(({ title, content, _id }, idx) => (
           <Link key={`${title}-${idx}`} href={`/article/${_id}`}>
             <div style={{ border: '1px solid black' }}>
               <div>{title}</div>

--- a/src/models/article.ts
+++ b/src/models/article.ts
@@ -14,7 +14,7 @@ const articleContentSchema = new Schema({
 const articleSchema = new Schema(
   {
     title: { type: String, required: true },
-    articleContentId: {
+    content: {
       type: Schema.Types.ObjectId,
       ref: 'ArticleContent',
       required: true,

--- a/src/models/article.ts
+++ b/src/models/article.ts
@@ -1,14 +1,33 @@
 import mongoose, { Schema } from 'mongoose'
 
+const articleContentSchema = new Schema({
+  text: {
+    type: String,
+    required: true,
+  },
+  html: {
+    type: String,
+    required: true,
+  },
+})
+
 const articleSchema = new Schema(
   {
-    title: String,
-    content: { text: String, html: String },
+    title: { type: String, required: true },
+    articleContentId: {
+      type: Schema.Types.ObjectId,
+      ref: 'ArticleContent',
+      required: true,
+    },
   },
   { timestamps: true },
 )
 
+const ArticleContent =
+  mongoose.models.ArticleContent ||
+  mongoose.model('ArticleContent', articleContentSchema)
+
 const Article =
   mongoose.models.Article || mongoose.model('Article', articleSchema)
 
-export default Article
+export { Article, ArticleContent }


### PR DESCRIPTION
# What is this PR?

데이터에서 article과 content 분리하기

# Changes

- 변경 내역 요약
    - 변경 전 : 하나의 article 데이터에 article에 관한 모든 정보가 들어있었음.
    - 변경 후 : 하나의 article 데이터에 article에 관한 개요 부분 (title 등)과 본문 (detail) 내용을 분리.
- 변경 내역 디테일
    - mongoDB의 collection이 articles와 articleContents로 분리됨.
        
        >   ✓ articles ⇒ article의 개요를 담음
              ✓ articleContents ⇒ article의 본문을 담음
        > 

        - 본문이 필요할 때, articleContents를 가져옴
            - 방법: `find().populate()`
    - Schema 분리
        - `articleContentSchema`, `articleSchema`
        - 두 스키마간 relation 설정
            - 방법 : id로 연결
                
                ```tsx
                content: {
                      type: Schema.Types.ObjectId,
                      ref: 'ArticleContent',
                      required: true,
                }
                ```

# Screenshot (성능 측정 결과_네트워크 탭)
약 5배 빨라짐
        
| action | image                      |
| ------ | -------------------------- |
| 분리 전    | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/0731cbb8-79c8-4ceb-b4e4-964a6160e2d5' height='200'/> |
| 분리 후     | <img src='https://github.com/katej927/dev-blog-forked/assets/69146527/bb1d8e52-df59-4e37-b627-b0c4d1f5d9b9' height='200'/> |

# Notes

- 분리 이유
    - 성능 최적화
        
        개요 부분만 보여줄 때는 본문 내용의 데이터를 들고 다니지 않는 것을 목표로 함.
        
        즉, 본문이 필요할 때만 본문을 가져오도록 함.
        
- 검색 기능 제대로 안되서 수정 필요함.

# Questions

- 더 잘 짤 방법이 있을지?

# Trouble Shooting

※ PR별 유의미한 트러블 슈팅을 기록하여 개인적으로 참고 하고자 적습니다.

<details>
        <summary>과연 할 수 있을까 싶었던 것을 도전하고 성공했다. (성능 최적화를 위한 백엔드 로직 수정 성공)</summary>

- 무엇을 하고 싶었는가?
    
    > 성능 최적화를 하고 싶었다.
    > 
    
    어느 부분을 하고 싶었냐면, PR 제목처럼 post에서 글의 내용과 개요를 분리하고 싶었다.
    
- 왜 하고 싶었는가?
    
    > 렌더링을 빠르게 하고 페이지가 가볍기를 바랬다.
    > 
    
    개요는 목록 UI에서 간단하면서 빠르게 보여주고 싶었다. 그런데 기존의 로직대로라면 개요 (제목, 간단한 설명) 정도만 보여주는데 모든 글의 내용을 load 받았어야 했다. content가 모든 글에 항상 붙어있었기 때문이다.
    
    지금이야 문제 없겠지만 앞으로 글이 많아지면 무거워질테고 그러면 렌더링이 느려질 것이라고 생각했다.
    
    느린 렌더링은 많이 비선호하는 편이고 프론트엔드 개발자로서도 받아들이기 어려운 부분이었다.
    
    비단 느린 렌더링 뿐 아니라 굳이 사용하지 않는 데이터를 들고 다닐 이유가 없다고 생각했다.
    
- 어떤 부분에서 구현을 망설였는가?
    
    > 백엔드를 잘 몰라서 못할 것만 같았다.
    > 
    
    괜히 실수했다가 꼬이면 어쩌지? 하는 걱정도 들었다.
    
- 어떻게 구현했는가?
    
    > 1. 백엔드 구현 로직 확인
    > 2. chatGPT로 수정 키워드 뽑아내기
    > 3. mongoose로 relation 설정하기 (populate 활용)
    > 
    1. 백엔드 구현 로직 확인
        
        우선 article을 구현하면서 참고했던 레퍼런스([Step-by-Step Guide: Create a Next.js 13 CRUD App with MongoDB from Scratch](https://youtu.be/wNWyMsrpbz0?si=HqccCslQlj0oIERU))를 다시 보면서 어떤 식으로 백엔드 코드를 짰었는지 다시 점검했다.
        
        그래도 잘 모르겠고 어떤 부분을 수정해야 할지 감이 잘 오질 않았다. 
        
    2. chatGPT로 수정 키워드 뽑아내기
        
        막막해서 chatGPT에게 물어보았다. 나의 Schema와 이 상태에서 내가 원하는 로직은 어떤 것인데 어떻게 구현해야 할지 모르겠다고.
        
        생각 보다 답을 잘 알려주었는데 그 코드가 어떻게 동작하는지 잘 모르겠고 정확성도 신뢰하기가 어려웠다. 그래서 수정된 부분이면서 중요 키워드로 보이는 코드를 따서 구글링 해보았다.
        
        해당 키워드는 `Schema.Types.ObjectId` 였다.
        
    3. mongoose로 relation 설정하기 (populate 활용)
        
        검색하니 바로 눈에 띄는 제목이 보였다. ‘**[mongoose로 relation 설정하기 (populate 이용하기)](https://fierycoding.tistory.com/35)**’
        
        읽어보니 내가 딱 원하던 내용이었다. 
        
        각 모델을 생성하고 아래의 코드를 통해 연결 할 수 있었다.
        
        ```jsx
        연결할 key: {
            type: Schema.Types.ObjectId, // id로 연결
            ref: 'Seller',
            required: true
          }
        ```
        
        그 후, `find().populate()` 를 통해 연결된 객체까지 조회할 수 있음을 알 수 있었다.
        
- 소감
    
    해낼 수 있을까 걱정도 되었는데 늘 하나씩, 차분히 해내기로 마음 먹고 난 후로 하나씩 실마리를 풀어감을 느꼈다. 
    
    그리고 이번에 해결했던 방법처럼 아예 감을 잡기 힘들때는 chatGPT에 키워드를 뽑고 자세한 것은 구글링을 통해 이해할 수 있지 않을까 하는 생각이 들었다.
    
    계속 차분히 해나가면 해낼 수 있구나 하는 자신감도 얻고 있다.
    
    중간중간 머리도 아팠지만.. 연속 2시간 반을 자리에서 스트레이트로 구현하는 날 보며 나는 여전히, 처음 프론트를 할 때 처럼 시간 가는 줄 모르고 하는 구나. 
    
    개발하길 잘한 것 같다는 생각이 들어서 보람찼다.
    
    아무튼.. 이번에도 좋은 경험을 한 것 같다. 수고했다.🤝
</details>
