### PR TITLE
design/editor : 에디터 디자인

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,7 @@ a {
   --color-theme-blue: #3182f6;
   --color-theme-red: #fa4e4e;
   --color-theme-gray: #979797;
+  --color-theme-light-gray: #e5e5e5;
   --color-theme-black: #333333;
 
   /* z-index */

--- a/src/components/ArticleContent/index.tsx
+++ b/src/components/ArticleContent/index.tsx
@@ -7,10 +7,13 @@ import { ArticleContentInterface } from '@/apis/articles'
 
 interface Props {
   contentHtml: ArticleContentInterface['html']
+  style?: {}
 }
 
-const ArticleContent = ({ contentHtml }: Props) => {
-  return <ReactQuill theme="bubble" value={contentHtml} readOnly />
+const ArticleContent = ({ contentHtml, style }: Props) => {
+  return (
+    <ReactQuill theme="bubble" value={contentHtml} readOnly style={style} />
+  )
 }
 
 export default ArticleContent

--- a/src/components/ArticleContent/index.tsx
+++ b/src/components/ArticleContent/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { CSSProperties } from 'react'
 import ReactQuill from 'react-quill'
 import 'react-quill/dist/quill.snow.css'
 
@@ -7,7 +8,7 @@ import { ArticleContentInterface } from '@/apis/articles'
 
 interface Props {
   contentHtml: ArticleContentInterface['html']
-  style?: {}
+  style?: CSSProperties
 }
 
 const ArticleContent = ({ contentHtml, style }: Props) => {

--- a/src/components/ArticleForm/ArticleSetupModal/CategorySetup/CategoryList/index.module.css
+++ b/src/components/ArticleForm/ArticleSetupModal/CategorySetup/CategoryList/index.module.css
@@ -49,6 +49,7 @@
   padding: 10px 0px;
   list-style-type: none;
   border-bottom: 1px solid var(--color-theme-gray);
+  cursor: pointer;
 
   &.active {
     color: white;

--- a/src/components/ArticleForm/ArticleSetupModal/CategorySetup/CategoryList/index.module.css
+++ b/src/components/ArticleForm/ArticleSetupModal/CategorySetup/CategoryList/index.module.css
@@ -7,6 +7,7 @@
 .editButtonsWrapper {
   display: flex;
   justify-content: end;
+  margin-bottom: 15px;
 }
 
 .newCategoryInput {
@@ -53,4 +54,10 @@
     color: white;
     background-color: var(--color-theme-blue);
   }
+}
+
+.categorySetupButtonsWrapper {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 15px;
 }

--- a/src/components/ArticleForm/ArticleSetupModal/CategorySetup/CategoryList/index.module.css
+++ b/src/components/ArticleForm/ArticleSetupModal/CategorySetup/CategoryList/index.module.css
@@ -1,5 +1,56 @@
+.wrapper {
+  padding: 15px;
+  background-color: var(--color-theme-light-gray);
+  border-radius: var(--border-radius-4);
+}
+
+.editButtonsWrapper {
+  display: flex;
+  justify-content: end;
+}
+
+.newCategoryInput {
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 8px;
+  border: none;
+  border-radius: var(--border-radius-4);
+  outline: none;
+}
+
+.button {
+  padding: 10px 20px;
+  font-weight: bold;
+  font-size: 16px;
+  border: none;
+  border-radius: var(--border-radius-4);
+  cursor: pointer;
+
+  &.cancel {
+    color: var(--color-theme-blue);
+    background-color: inherit;
+  }
+
+  &.add,
+  &.select {
+    margin-left: 14px;
+    color: white;
+    background-color: var(--color-theme-blue);
+  }
+}
+
+.categoriesWrapper {
+  height: 250px;
+  overflow-y: auto;
+}
+
 .category {
+  padding: 10px 0px;
+  list-style-type: none;
+  border-bottom: 1px solid var(--color-theme-gray);
+
   &.active {
-    background-color: red;
+    color: white;
+    background-color: var(--color-theme-blue);
   }
 }

--- a/src/components/ArticleForm/ArticleSetupModal/CategorySetup/CategoryList/index.tsx
+++ b/src/components/ArticleForm/ArticleSetupModal/CategorySetup/CategoryList/index.tsx
@@ -74,23 +74,32 @@ function CategoryList({
   }
 
   return (
-    <section>
+    <section className={cx('wrapper')}>
       <input
         value={newCategoryName}
         type="text"
         placeholder="새로운 카테고리 이름을 입력하세요."
         onChange={handleChangeNewCategoryName}
+        className={cx('newCategoryInput')}
       />
-      <div>
-        <button type="button" onClick={() => setNewCategoryName('')}>
+      <div className={cx('editButtonsWrapper')}>
+        <button
+          className={cx('button', 'cancel')}
+          type="button"
+          onClick={() => setNewCategoryName('')}
+        >
           취소
         </button>
-        <button type="button" onClick={handleClickCreatingNewCategoryButton}>
+        <button
+          className={cx('button', 'add')}
+          type="button"
+          onClick={handleClickCreatingNewCategoryButton}
+        >
           카테고리 추가
         </button>
       </div>
 
-      <ul>
+      <ul className={cx('categoriesWrapper')}>
         {categories.length ? (
           categories.map(({ _id, categoryName }) => (
             <li
@@ -108,10 +117,15 @@ function CategoryList({
           <div>카테고리가 없습니다.</div>
         )}
       </ul>
-      <button type="button" onClick={() => toggleCategoryList()}>
+      <button
+        className={cx('button', 'cancel')}
+        type="button"
+        onClick={() => toggleCategoryList()}
+      >
         취소
       </button>
       <button
+        className={cx('button', 'select')}
         type="button"
         onClick={handleClickSelectCategoryButton}
         disabled={!clickedCategory}

--- a/src/components/ArticleForm/ArticleSetupModal/CategorySetup/CategoryList/index.tsx
+++ b/src/components/ArticleForm/ArticleSetupModal/CategorySetup/CategoryList/index.tsx
@@ -117,21 +117,23 @@ function CategoryList({
           <div>카테고리가 없습니다.</div>
         )}
       </ul>
-      <button
-        className={cx('button', 'cancel')}
-        type="button"
-        onClick={() => toggleCategoryList()}
-      >
-        취소
-      </button>
-      <button
-        className={cx('button', 'select')}
-        type="button"
-        onClick={handleClickSelectCategoryButton}
-        disabled={!clickedCategory}
-      >
-        선택하기
-      </button>
+      <div className={cx('categorySetupButtonsWrapper')}>
+        <button
+          className={cx('button', 'cancel')}
+          type="button"
+          onClick={() => toggleCategoryList()}
+        >
+          취소
+        </button>
+        <button
+          className={cx('button', 'select')}
+          type="button"
+          onClick={handleClickSelectCategoryButton}
+          disabled={!clickedCategory}
+        >
+          선택하기
+        </button>
+      </div>
     </section>
   )
 }

--- a/src/components/ArticleForm/ArticleSetupModal/CategorySetup/index.module.css
+++ b/src/components/ArticleForm/ArticleSetupModal/CategorySetup/index.module.css
@@ -1,3 +1,11 @@
+.wrapper {
+  width: 350px;
+}
+
+.title {
+  margin-bottom: 8px;
+}
+
 .selectedCategoryWrapper {
   display: none;
 
@@ -8,6 +16,15 @@
 
 .addCategoryButton {
   display: none;
+  width: 100%;
+  height: 48px;
+  color: var(--color-theme-blue);
+  font-weight: bold;
+  font-size: 16px;
+  background-color: var(--color-theme-light-gray);
+  border: none;
+  border-radius: var(--border-radius-4);
+  cursor: pointer;
 
   &.renderIf {
     display: inline-block;

--- a/src/components/ArticleForm/ArticleSetupModal/CategorySetup/index.module.css
+++ b/src/components/ArticleForm/ArticleSetupModal/CategorySetup/index.module.css
@@ -8,10 +8,26 @@
 
 .selectedCategoryWrapper {
   display: none;
+  width: 100%;
 
   &.renderIf {
-    display: inline-block;
+    display: flex;
+    flex-direction: column;
+    align-items: end;
   }
+}
+
+.name {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 48px;
+  background-color: var(--color-theme-light-gray);
+  border-radius: var(--border-radius-4);
+}
+
+.removalButton {
 }
 
 .addCategoryButton {

--- a/src/components/ArticleForm/ArticleSetupModal/CategorySetup/index.module.css
+++ b/src/components/ArticleForm/ArticleSetupModal/CategorySetup/index.module.css
@@ -20,14 +20,20 @@
 .name {
   display: flex;
   align-items: center;
-  justify-content: center;
   width: 100%;
   height: 48px;
+  margin-bottom: 8px;
+  padding: 0px 16px;
   background-color: var(--color-theme-light-gray);
   border-radius: var(--border-radius-4);
 }
 
 .removalButton {
+  color: var(--color-theme-red);
+  font-size: 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
 }
 
 .addCategoryButton {

--- a/src/components/ArticleForm/ArticleSetupModal/CategorySetup/index.tsx
+++ b/src/components/ArticleForm/ArticleSetupModal/CategorySetup/index.tsx
@@ -32,8 +32,12 @@ function CategorySetup({ updateSelectedCategory, selectedCategory }: Props) {
           renderIf: !isShowCategoryList && selectedCategory,
         })}
       >
-        <div>{selectedCategory?.categoryName}</div>
-        <button type="button" onClick={handleClickRemoveCategory}>
+        <div className={cx('name')}>{selectedCategory?.categoryName}</div>
+        <button
+          className={cx('removalButton')}
+          type="button"
+          onClick={handleClickRemoveCategory}
+        >
           카테고리에서 제거
         </button>
       </div>

--- a/src/components/ArticleForm/ArticleSetupModal/CategorySetup/index.tsx
+++ b/src/components/ArticleForm/ArticleSetupModal/CategorySetup/index.tsx
@@ -20,8 +20,8 @@ function CategorySetup({ updateSelectedCategory, selectedCategory }: Props) {
   const handleClickRemoveCategory = () => updateSelectedCategory(null)
 
   return (
-    <div>
-      <h3>카테고리 설정</h3>
+    <section className={cx('wrapper')}>
+      <h3 className={cx('title')}>카테고리 설정</h3>
       <CategoryList
         renderIf={isShowCategoryList}
         updateSelectedCategory={updateSelectedCategory}
@@ -46,7 +46,7 @@ function CategorySetup({ updateSelectedCategory, selectedCategory }: Props) {
       >
         카테고리에 추가하기
       </button>
-    </div>
+    </section>
   )
 }
 

--- a/src/components/ArticleForm/ArticleSetupModal/index.module.css
+++ b/src/components/ArticleForm/ArticleSetupModal/index.module.css
@@ -10,3 +10,16 @@
   justify-content: center;
   background-color: white;
 }
+
+.publishButton {
+  height: 48px;
+  margin-top: 32px;
+  padding: 0px 18px;
+  color: white;
+  font-weight: bold;
+  font-size: 16px;
+  background-color: var(--color-theme-blue);
+  border: none;
+  border-radius: var(--border-radius-4);
+  cursor: pointer;
+}

--- a/src/components/ArticleForm/ArticleSetupModal/index.module.css
+++ b/src/components/ArticleForm/ArticleSetupModal/index.module.css
@@ -1,4 +1,4 @@
-.container {
+.wrapper {
   position: absolute;
   top: 0;
   right: 0;

--- a/src/components/ArticleForm/ArticleSetupModal/index.tsx
+++ b/src/components/ArticleForm/ArticleSetupModal/index.tsx
@@ -1,11 +1,10 @@
 import { useState } from 'react'
+import classNames from 'classnames/bind'
 
 import CategorySetup from './CategorySetup'
 import { SelectedCategoryType } from './_shared'
 import { Props } from '../_shared'
 import styles from './index.module.css'
-
-import classNames from 'classnames/bind'
 
 const cx = classNames.bind(styles)
 

--- a/src/components/ArticleForm/ArticleSetupModal/index.tsx
+++ b/src/components/ArticleForm/ArticleSetupModal/index.tsx
@@ -5,6 +5,10 @@ import { SelectedCategoryType } from './_shared'
 import { Props } from '../_shared'
 import styles from './index.module.css'
 
+import classNames from 'classnames/bind'
+
+const cx = classNames.bind(styles)
+
 function ArticleSetupModal({ title, content, category, onSubmit }: Props) {
   const [selectedCategory, setSelectedCategory] =
     useState<SelectedCategoryType>(category)
@@ -21,12 +25,16 @@ function ArticleSetupModal({ title, content, category, onSubmit }: Props) {
   }
 
   return (
-    <section className={styles.container}>
+    <section className={cx('container')}>
       <CategorySetup
         updateSelectedCategory={updateSelectedCategory}
         selectedCategory={selectedCategory}
       />
-      <button type="submit" onClick={handleClickPublishButton}>
+      <button
+        className={cx('publishButton')}
+        type="submit"
+        onClick={handleClickPublishButton}
+      >
         출간하기
       </button>
     </section>

--- a/src/components/ArticleForm/ArticleSetupModal/index.tsx
+++ b/src/components/ArticleForm/ArticleSetupModal/index.tsx
@@ -24,7 +24,7 @@ function ArticleSetupModal({ title, content, category, onSubmit }: Props) {
   }
 
   return (
-    <section className={cx('container')}>
+    <section className={cx('wrapper')}>
       <CategorySetup
         updateSelectedCategory={updateSelectedCategory}
         selectedCategory={selectedCategory}

--- a/src/components/ArticleForm/Editor/index.tsx
+++ b/src/components/ArticleForm/Editor/index.tsx
@@ -22,7 +22,6 @@ const Editor = ({ contentHtml, onChangeContent }: Props) => {
   return (
     <ReactQuill
       theme="snow"
-      style={{ height: '600px' }}
       onChange={(value, delta, source, editor) =>
         onChangeContent({
           text: editor.getText(),

--- a/src/components/ArticleForm/Editor/index.tsx
+++ b/src/components/ArticleForm/Editor/index.tsx
@@ -22,6 +22,10 @@ const Editor = ({ contentHtml, onChangeContent }: Props) => {
   return (
     <ReactQuill
       theme="snow"
+      style={{
+        height: '550px',
+        display: 'inline-block',
+      }}
       onChange={(value, delta, source, editor) =>
         onChangeContent({
           text: editor.getText(),

--- a/src/components/ArticleForm/index.module.css
+++ b/src/components/ArticleForm/index.module.css
@@ -1,4 +1,5 @@
 .title {
+  width: 100%;
   font-weight: bold;
   font-size: 35px;
   border: none;
@@ -16,4 +17,5 @@
   background-color: var(--color-theme-blue);
   border: none;
   border-radius: var(--border-radius-4);
+  cursor: pointer;
 }

--- a/src/components/ArticleForm/index.module.css
+++ b/src/components/ArticleForm/index.module.css
@@ -1,9 +1,19 @@
 .title {
   font-weight: bold;
+  font-size: 35px;
   border: none;
   outline: none;
 }
 
 .editorWrapper {
   display: flex;
+}
+
+.publishButton {
+  padding: 11px 20px;
+  color: white;
+  font-size: 16px;
+  background-color: var(--color-theme-blue);
+  border: none;
+  border-radius: var(--border-radius-4);
 }

--- a/src/components/ArticleForm/index.module.css
+++ b/src/components/ArticleForm/index.module.css
@@ -1,3 +1,9 @@
+.wrapper {
+  position: absolute;
+  right: 0;
+  left: 0;
+}
+
 .title {
   width: 100%;
   font-weight: bold;
@@ -8,6 +14,18 @@
 
 .editorWrapper {
   display: flex;
+}
+
+.left,
+.right {
+  width: 50%;
+  padding: 0px 30px;
+}
+
+.publishButtonWrapper {
+  display: flex;
+  justify-content: flex-end;
+  padding: 15px 0px;
 }
 
 .publishButton {

--- a/src/components/ArticleForm/index.module.css
+++ b/src/components/ArticleForm/index.module.css
@@ -1,0 +1,9 @@
+.title {
+  font-weight: bold;
+  border: none;
+  outline: none;
+}
+
+.editorWrapper {
+  display: flex;
+}

--- a/src/components/ArticleForm/index.tsx
+++ b/src/components/ArticleForm/index.tsx
@@ -39,9 +39,9 @@ const ArticleForm = ({ title, content, category, onSubmit }: Props) => {
   }
 
   return (
-    <section>
+    <section className={cx('wrapper')}>
       <section className={cx('editorWrapper')}>
-        <div>
+        <div className={cx('left')}>
           <input
             onChange={handleChangeNewTitle}
             value={newTitle}
@@ -53,8 +53,17 @@ const ArticleForm = ({ title, content, category, onSubmit }: Props) => {
             contentHtml={newContent.html}
             onChangeContent={handleChangeNewContent}
           />
+          <div className={cx('publishButtonWrapper')}>
+            <button
+              className={cx('publishButton')}
+              type="button"
+              onClick={handleSubmitTitleContent}
+            >
+              출간하기
+            </button>
+          </div>
         </div>
-        <div>
+        <div className={cx('right')}>
           <input
             readOnly
             value={newTitle}
@@ -64,13 +73,7 @@ const ArticleForm = ({ title, content, category, onSubmit }: Props) => {
           <ArticleContent contentHtml={newContent.html} />
         </div>
       </section>
-      <button
-        className={cx('publishButton')}
-        type="button"
-        onClick={handleSubmitTitleContent}
-      >
-        출간하기
-      </button>
+
       {isShowModal &&
         createPortal(
           <ArticleSetupModal

--- a/src/components/ArticleForm/index.tsx
+++ b/src/components/ArticleForm/index.tsx
@@ -70,7 +70,12 @@ const ArticleForm = ({ title, content, category, onSubmit }: Props) => {
             type="text"
             className={cx('title')}
           />
-          <ArticleContent contentHtml={newContent.html} />
+          <ArticleContent
+            contentHtml={newContent.html}
+            style={{
+              height: '670px',
+            }}
+          />
         </div>
       </section>
 

--- a/src/components/ArticleForm/index.tsx
+++ b/src/components/ArticleForm/index.tsx
@@ -2,11 +2,16 @@
 
 import { ChangeEvent, useState } from 'react'
 import { createPortal } from 'react-dom'
+import classNames from 'classnames/bind'
 
 import Editor from './Editor'
 import ArticleContent from '../ArticleContent'
 import { Props, NewContentType, NewTitleType } from './_shared'
 import ArticleSetupModal from './ArticleSetupModal'
+
+import styles from './index.module.css'
+
+const cx = classNames.bind(styles)
 
 const ArticleForm = ({ title, content, category, onSubmit }: Props) => {
   const [newTitle, setNewTitle] = useState<NewTitleType>(title)
@@ -35,22 +40,28 @@ const ArticleForm = ({ title, content, category, onSubmit }: Props) => {
 
   return (
     <section>
+      <section className={cx('editorWrapper')}>
+        <div>
+          <input
+            onChange={handleChangeNewTitle}
+            value={newTitle}
+            type="text"
+            placeholder="제목을 입력하세요"
+            className={cx('title')}
+          />
+          <Editor
+            contentHtml={newContent.html}
+            onChangeContent={handleChangeNewContent}
+          />
+        </div>
+        <div>
+          <input value={newTitle} type="text" className={cx('title')} />
+          <ArticleContent contentHtml={newContent.html} />
+        </div>
+      </section>
       <button type="button" onClick={handleSubmitTitleContent}>
         출간하기
       </button>
-      <input
-        onChange={handleChangeNewTitle}
-        value={newTitle}
-        type="text"
-        placeholder="Text title..."
-      />
-      <div style={{ display: 'flex' }}>
-        <Editor
-          contentHtml={newContent.html}
-          onChangeContent={handleChangeNewContent}
-        />
-        <ArticleContent contentHtml={newContent.html} />
-      </div>
       {isShowModal &&
         createPortal(
           <ArticleSetupModal

--- a/src/components/ArticleForm/index.tsx
+++ b/src/components/ArticleForm/index.tsx
@@ -55,11 +55,20 @@ const ArticleForm = ({ title, content, category, onSubmit }: Props) => {
           />
         </div>
         <div>
-          <input value={newTitle} type="text" className={cx('title')} />
+          <input
+            readOnly
+            value={newTitle}
+            type="text"
+            className={cx('title')}
+          />
           <ArticleContent contentHtml={newContent.html} />
         </div>
       </section>
-      <button type="button" onClick={handleSubmitTitleContent}>
+      <button
+        className={cx('publishButton')}
+        type="button"
+        onClick={handleSubmitTitleContent}
+      >
         출간하기
       </button>
       {isShowModal &&

--- a/src/components/ArticleForm/index.tsx
+++ b/src/components/ArticleForm/index.tsx
@@ -8,7 +8,6 @@ import Editor from './Editor'
 import ArticleContent from '../ArticleContent'
 import { Props, NewContentType, NewTitleType } from './_shared'
 import ArticleSetupModal from './ArticleSetupModal'
-
 import styles from './index.module.css'
 
 const cx = classNames.bind(styles)


### PR DESCRIPTION
# What is this PR?

- 에디터 디자인

# Changes

- 에디터 크기 조율
- 카테고리 스타일링
- 기타
    - className 라이브러리를 통해 조건적으로 스타일을 주도록 함.
    - ArticleContent에 style을 유동적으로 줄 수 있도록 함
        
        → 글 작성 시, 높이 조절 가능하게 만듦.
        

# Screenshot

| action | image                      |
| ------ | -------------------------- |
| 1. 에디터 진입 후, 글 작성     | <img src='https://github.com/katej927/kate-devlog/assets/69146527/5d73dea9-a8c9-4560-9756-c24e963e5a5f' height='200'/> |
| 2. 출간하기 버튼 눌러서 카테고리 설정 모달 진입     | <img src='https://github.com/katej927/kate-devlog/assets/69146527/7f070d56-0d7e-478e-8d1c-596a5edcb254' height='200'/> |
| 3. 카테고리 추가하기 버튼 눌러서 카테고리 리스트 확인     | <img src='https://github.com/katej927/kate-devlog/assets/69146527/0427c9a1-af0e-4cea-a892-e54ce02288c8' height='200'/> |
| 4. 카테고리 선택 후, 선택된 카테고리 확인     | <img src='https://github.com/katej927/kate-devlog/assets/69146527/1e818fb3-9208-439d-b23e-417e173e19cb' height='200'/> |
| 5. 카테고리 제거 버튼 클릭 후, 제거 확인     | <img src='https://github.com/katej927/kate-devlog/assets/69146527/67510d73-c9f1-4912-8ed6-5c1cc74be2a3' height='200'/> |

# Notes

더 잘 짤 수 있는 방법이 있을까.

# Test Checklist

screenshot 참고

# Trouble Shooting

※ PR별 유의미한 트러블 슈팅을 기록하여 개인적으로 참고 하고자 적습니다.

<details>
<summary>네비게이션 바를 유지하느냐 제거하느냐</summary>
벨로그를 많이 참고 하면서 벨로그처럼 글 작성 시, 네비게이션 바를 없애고 싶었다.

하지만 도저히 전역적으로 사용되는 네비게이션 바를 어떻게 없애는 게 적절한지 모르겠어서 그냥 유지하기로 했다.

왜냐면 네비게이션 바가 있으나 없으나 기능 상 차이는 크게 없기 때문이다.

이를 위해 zustand 도입도 고민했으나 Provider 위에 상태를 끌어와야 할 것 같아서 이것도 의미 없는 방법이라고 생각되어 접었다.

지금 생각해보면 시간 관계상 잘한 선택 같다.
</details>

<details>
<summary>에디터 높이 수정 하기</summary>
에디터 높이를 수정하려고 하는데 적절한 방법을 모르겠더라. 

quill의 issue 탭에 들어가보니 내부의 class name을 통해서 조절하라고 하는 것 같은데 그렇게 적용하려고 하니 style-lint 에러가 났다.

그리고 여전히 아래에 있던 버튼이 에디터랑 겹쳐 보이는 문제가 있었다.

해결 방법을 모색하다가 일단 개발자 도구로 들어가서 에디터의 height를 조절해보고 display 문제 인 것 같아서 display를 하나씩 쭉 적용해보니 잘 적용되는 속성을 발견할 수 있었다. (inline-block)

그래서 그 방법으로 해결할 수 있었고 안도할 수 있었다.

끝까지 포기 하지 않고 해결한 나 칭찬해주고 싶다 👏
</details>
